### PR TITLE
Native code must call result callback

### DIFF
--- a/android/src/main/kotlin/com/nover/interactivewebview/InteractiveWebviewPlugin.kt
+++ b/android/src/main/kotlin/com/nover/interactivewebview/InteractiveWebviewPlugin.kt
@@ -69,7 +69,7 @@ class InteractiveWebviewPlugin(activity: Activity): MethodCallHandler {
             CallMethod.loadUrl -> loadUrl(call)
         }
 
-        result(null)
+        result.success()
     }
 
     private fun setOptions(call: MethodCall) {

--- a/android/src/main/kotlin/com/nover/interactivewebview/InteractiveWebviewPlugin.kt
+++ b/android/src/main/kotlin/com/nover/interactivewebview/InteractiveWebviewPlugin.kt
@@ -68,6 +68,8 @@ class InteractiveWebviewPlugin(activity: Activity): MethodCallHandler {
             CallMethod.loadHTML -> loadHTML(call)
             CallMethod.loadUrl -> loadUrl(call)
         }
+
+        result(null)
     }
 
     private fun setOptions(call: MethodCall) {

--- a/android/src/main/kotlin/com/nover/interactivewebview/InteractiveWebviewPlugin.kt
+++ b/android/src/main/kotlin/com/nover/interactivewebview/InteractiveWebviewPlugin.kt
@@ -69,7 +69,7 @@ class InteractiveWebviewPlugin(activity: Activity): MethodCallHandler {
             CallMethod.loadUrl -> loadUrl(call)
         }
 
-        result.success()
+        result.success(null)
     }
 
     private fun setOptions(call: MethodCall) {

--- a/ios/Classes/SwiftInteractiveWebviewPlugin.swift
+++ b/ios/Classes/SwiftInteractiveWebviewPlugin.swift
@@ -34,6 +34,8 @@ public class SwiftInteractiveWebviewPlugin: NSObject, FlutterPlugin {
         case .loadHTML: loadHTML(call)
         case .loadUrl: loadUrl(call)
         }
+
+        result(nil)
     }
     
     init(withChannel channel: FlutterMethodChannel) {


### PR DESCRIPTION
Currently the native code is not returning a future to flutter. If you call await loadUrl, the await never gets resolved. This simple fix will properly return from native code.